### PR TITLE
api: change byte-count type from uint32_t to size_t

### DIFF
--- a/cbox.h
+++ b/cbox.h
@@ -8,7 +8,7 @@
 typedef struct CBoxVec CBoxVec;
 
 uint8_t * cbox_vec_data(CBoxVec const * v);
-uint32_t  cbox_vec_len(CBoxVec  const * v);
+size_t    cbox_vec_len(CBoxVec  const * v);
 void      cbox_vec_free(CBoxVec * v);
 
 // CBoxResult ///////////////////////////////////////////////////////////////
@@ -50,14 +50,14 @@ CBoxResult
 cbox_session_init_from_prekey(CBox * b,
                               char const * sid,
                               uint8_t const * prekey,
-                              uint32_t prekey_len,
+                              size_t prekey_len,
                               CBoxSession ** s);
 
 CBoxResult
 cbox_session_init_from_message(CBox * b,
                                char const * sid,
                                uint8_t const * cipher,
-                               uint32_t cipher_len,
+                               size_t cipher_len,
                                CBoxSession ** s,
                                CBoxVec ** plain);
 
@@ -66,10 +66,10 @@ CBoxResult   cbox_session_save(CBoxSession * s);
 char const * cbox_session_id(CBoxSession const * s);
 void         cbox_session_close(CBoxSession * s);
 CBoxResult   cbox_session_delete(CBox * b, char const * sid);
-CBoxResult   cbox_encrypt(CBoxSession * s, uint8_t const * plain, uint32_t plain_len, CBoxVec ** cipher);
-CBoxResult   cbox_decrypt(CBoxSession * s, uint8_t const * cipher, uint32_t cipher_len, CBoxVec ** plain);
+CBoxResult   cbox_encrypt(CBoxSession * s, uint8_t const * plain, size_t plain_len, CBoxVec ** cipher);
+CBoxResult   cbox_decrypt(CBoxSession * s, uint8_t const * cipher, size_t cipher_len, CBoxVec ** plain);
 void         cbox_fingerprint_local(CBox const * b, CBoxVec ** buf);
 void         cbox_fingerprint_remote(CBoxSession const * s, CBoxVec ** buf);
-CBoxVec *    cbox_random_bytes(CBox const * b, uint32_t len);
+CBoxVec *    cbox_random_bytes(CBox const * b, size_t len);
 
 #endif // __CRYPTOBOX_H__

--- a/src/api.rs
+++ b/src/api.rs
@@ -159,7 +159,7 @@ pub unsafe extern
 fn cbox_session_init_from_prekey(c_box:         *mut   CBox,
                                  c_sid:         *const c_char,
                                  c_prekey:      *const uint8_t,
-                                 c_prekey_len:  uint32_t,
+                                 c_prekey_len:  size_t,
                                  c_session:     *mut *const CBoxSession) -> CBoxResult
 {
     let cbox   = &*c_box;
@@ -177,7 +177,7 @@ pub unsafe extern
 fn cbox_session_init_from_message(c_box:        *mut CBox,
                                   c_sid:        *const c_char,
                                   c_cipher:     *const uint8_t,
-                                  c_cipher_len: uint32_t,
+                                  c_cipher_len: size_t,
                                   c_sess:       *mut *mut CBoxSession,
                                   c_plain:      *mut *mut CBoxVec) -> CBoxResult
 {
@@ -242,7 +242,7 @@ fn cbox_session_delete(c_box: *mut CBox, c_sid: *const c_char) -> CBoxResult {
 pub unsafe extern
 fn cbox_encrypt(c_sess:      *mut CBoxSession,
                 c_plain:     *const uint8_t,
-                c_plain_len: uint32_t,
+                c_plain_len: size_t,
                 c_cipher:    *mut *mut CBoxVec) -> CBoxResult
 {
     let sref   = &mut *c_sess;
@@ -256,7 +256,7 @@ fn cbox_encrypt(c_sess:      *mut CBoxSession,
 pub unsafe extern
 fn cbox_decrypt(c_sess:       *mut CBoxSession,
                 c_cipher:     *const uint8_t,
-                c_cipher_len: uint32_t,
+                c_cipher_len: size_t,
                 c_plain:      *mut *mut CBoxVec) -> CBoxResult
 {
     let session = &mut *c_sess;
@@ -304,8 +304,8 @@ pub unsafe extern fn cbox_vec_data(v: *const CBoxVec) -> *const uint8_t {
 }
 
 #[no_mangle]
-pub unsafe extern fn cbox_vec_len(v: *const CBoxVec) -> uint32_t {
-    (*v).vec.len() as uint32_t
+pub unsafe extern fn cbox_vec_len(v: *const CBoxVec) -> size_t {
+    (*v).vec.len() as size_t
 }
 
 // CBoxResult ///////////////////////////////////////////////////////////////
@@ -384,7 +384,7 @@ impl From<NulError> for CBoxResult {
 // Util /////////////////////////////////////////////////////////////////////
 
 #[no_mangle]
-pub unsafe extern fn cbox_random_bytes(_: *const CBox, n: uint32_t) -> *mut CBoxVec {
+pub unsafe extern fn cbox_random_bytes(_: *const CBox, n: size_t) -> *mut CBoxVec {
     CBoxVec::from_vec(keys::rand_bytes(n as usize))
 }
 


### PR DESCRIPTION
it is quite common to use `size_t'.

ref: http://stackoverflow.com/questions/994288/size-t-vs-int-in-c-and-or-c