### PR TITLE
Update to match latest proteus developments.

### DIFF
--- a/cbox.h
+++ b/cbox.h
@@ -73,7 +73,11 @@ typedef enum {
 
     // A CBox has been opened with an incomplete or mismatching identity.
     // This is typically a programmer error.
-    CBOX_IDENTITY_ERROR          = 13
+    CBOX_IDENTITY_ERROR          = 13,
+
+    // An attempt was made to initialise a new session with a prekey ID
+    // for which no prekey could be found.
+    CBOX_PREKEY_NOT_FOUND        = 14
 } CBoxResult;
 
 //////////////////////

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,8 +3,6 @@
 // the MPL was not distributed with this file, You
 // can obtain one at http://mozilla.org/MPL/2.0/.
 
-#![feature(box_raw)]
-
 extern crate byteorder;
 extern crate cbor;
 extern crate libc;

--- a/src/store/api.rs
+++ b/src/store/api.rs
@@ -16,7 +16,7 @@ use std::io;
 
 pub type StorageResult<T> = Result<T, StorageError>;
 
-pub trait Store: PreKeyStore<StorageError> {
+pub trait Store: PreKeyStore {
     fn load_session<'r>(&self, li: &'r IdentityKeyPair, id: &str) -> StorageResult<Option<Session<'r>>>;
     fn save_session(&self, id: &str, s: &Session) -> StorageResult<()>;
     fn delete_session(&self, id: &str) -> StorageResult<()>;

--- a/src/store/file.rs
+++ b/src/store/file.rs
@@ -133,8 +133,10 @@ impl Store for FileStore {
     }
 }
 
-impl PreKeyStore<StorageError> for FileStore {
-    fn prekey(&self, id: PreKeyId) -> StorageResult<Option<PreKey>> {
+impl PreKeyStore for FileStore {
+    type Error = StorageError;
+
+    fn prekey(&mut self, id: PreKeyId) -> StorageResult<Option<PreKey>> {
         let path = self.prekey_dir.join(&id.value().to_string());
         match try!(load_file(&path)) {
             Some(b) => PreKey::deserialise(&b).map_err(From::from).map(Some),

--- a/test/main.c
+++ b/test/main.c
@@ -125,7 +125,7 @@ void test_prekey_removal(CBox * alice_box, CBox * bob_box) {
     cbox_session_close(bob);
     cbox_vec_free(plain);
     rc = cbox_session_init_from_message(bob_box, "bob", cbox_vec_data(cipher), cbox_vec_len(cipher), &bob, &plain);
-    assert(rc == CBOX_INVALID_MESSAGE);
+    assert(rc == CBOX_PREKEY_NOT_FOUND);
 
     // Cleanup
     cbox_vec_free(bob_prekey);


### PR DESCRIPTION
1. Add `PreKeyNotFound` error.
2. Modify prekey store implementations to use associated types and `&mut self` in PreKeyStore::prekey`.